### PR TITLE
[smoke-fort-fails] Add test case to check performance of use_dev_addr

### DIFF
--- a/test/smoke-fort-fails/flang-use-dev-addr-performance/Makefile
+++ b/test/smoke-fort-fails/flang-use-dev-addr-performance/Makefile
@@ -9,7 +9,7 @@ HIPCC ?= $(AOMPHIP)/bin/hipcc
 HIP_CLANG_PATH ?= $(AOMP)/bin
 
 CFLAGS = -O3
-FLANG        ?= flang -save-temps
+FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 EXTRA_CFLAGS = -L$(AOMPHIP)/lib -lamdhip64 -Wl,-rpath,$(AOMPHIP)/lib -fPIC

--- a/test/smoke-fort-fails/flang-use-dev-addr-performance/Makefile
+++ b/test/smoke-fort-fails/flang-use-dev-addr-performance/Makefile
@@ -1,0 +1,26 @@
+include ../../Makefile.defs
+
+TESTNAME     = use-dev-addr-performance
+TESTSRC_MAIN = main.f90
+TESTSRC_AUX  = bar.o
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+AOMPHIP ?= $(AOMP)
+HIPCC ?= $(AOMPHIP)/bin/hipcc
+HIP_CLANG_PATH ?= $(AOMP)/bin
+
+CFLAGS = -O3
+FLANG        ?= flang -save-temps
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+EXTRA_CFLAGS = -L$(AOMPHIP)/lib -lamdhip64 -Wl,-rpath,$(AOMPHIP)/lib -fPIC
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+all: $(TESTNAME)
+
+bar.o : bar.hip
+	HIP_CLANG_PATH=$(HIP_CLANG_PATH) $(HIPCC) -c --offload-arch=$(AOMP_GPU) -fPIC $^ -o $@
+
+run: $(TESTNAME)
+	 LIBOMPTARGET_INFO=8 ./$(TESTNAME)  2>&1 | $(AOMP)/bin/FileCheck check.txt

--- a/test/smoke-fort-fails/flang-use-dev-addr-performance/bar.hip
+++ b/test/smoke-fort-fails/flang-use-dev-addr-performance/bar.hip
@@ -1,0 +1,27 @@
+#include <hip/hip_runtime.h>
+#include <stdlib.h>
+
+__global__ void bar_kernel(int *x, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i < n) {
+           x[i]++;
+    }
+}
+
+extern "C" {
+
+void bar_GPU(int *x, int n)
+{
+    int num_threads = 256;
+    int num_blocks = n / num_threads + 1;
+    hipLaunchKernelGGL(bar_kernel, dim3(num_blocks), dim3(num_threads), 0, 0, x, n);
+    (void)hipDeviceSynchronize();
+}
+
+void print_ptr(int * x) {
+    static int cnt;
+    printf("pointer x %lx number of calls: %d\n",(ulong)x, ++cnt);
+}
+} /* extern "C" */

--- a/test/smoke-fort-fails/flang-use-dev-addr-performance/check.txt
+++ b/test/smoke-fort-fails/flang-use-dev-addr-performance/check.txt
@@ -1,0 +1,13 @@
+; CHECK: Creating new map entry
+; CHECK: Creating new map entry
+; CHECK-NOT: Creating new map entry
+; CHECK: Removing map entry
+; CHECK: Removing map entry
+; CHECK-NOT: Removing map entry
+; CHECK: Success
+; CHECK: pointer x [[ADDR:[0-9a-f]+]] number of calls: 1
+; CHECK: pointer x [[ADDR]] number of calls: 2
+; CHECK: pointer x [[GPU_ADDR:[0-9a-f]+]] number of calls: 3
+; CHECK: pointer x [[GPU_ADDR]] number of calls: 4
+; CHECK: pointer x [[ADDR]] number of calls: 5
+

--- a/test/smoke-fort-fails/flang-use-dev-addr-performance/main.f90
+++ b/test/smoke-fort-fails/flang-use-dev-addr-performance/main.f90
@@ -1,0 +1,65 @@
+MODULE foo
+  USE iso_c_binding
+  USE omp_lib
+  IMPLICIT NONE
+  PRIVATE
+  PUBLIC :: bar_device_addr, print_ptr, bar
+
+  INTERFACE
+    SUBROUTINE bar(x, n) BIND(C, name="bar_GPU")
+      USE iso_c_binding
+      TYPE(C_PTR),    VALUE, INTENT(IN)    :: x
+      INTEGER(C_INT), VALUE, INTENT(IN)    :: n
+    END SUBROUTINE
+    SUBROUTINE print_ptr(x) BIND(C, name="print_ptr")
+      USE iso_c_binding
+      TYPE(C_PTR),    VALUE, INTENT(IN)    :: x
+    END SUBROUTINE
+
+  END INTERFACE
+
+CONTAINS
+
+  SUBROUTINE bar_device_addr(x, n)
+    INTEGER, TARGET, INTENT(IN)    :: x(:)
+    INTEGER(C_INT), INTENT(IN)     :: n
+    !$omp target data use_device_addr (x)
+    CALL print_ptr(c_loc(x))
+    CALL bar(c_loc(x), n)
+    !$omp end target data
+  END SUBROUTINE
+
+END MODULE foo
+
+PROGRAM test_ptr
+  USE iso_c_binding
+  USE, intrinsic :: iso_fortran_env, only: error_unit
+  USE omp_lib
+  USE foo
+  IMPLICIT NONE
+
+  INTEGER, ALLOCATABLE, TARGET :: x(:)
+  INTEGER(C_INT) :: i, n
+  n = 1000
+  ALLOCATE(x(n))
+  x = 1
+  CALL print_ptr(c_loc(x))
+  !$omp target enter data map(to: x)
+     CALL print_ptr(c_loc(x))
+  !$omp target data use_device_addr (x)
+    CALL print_ptr(c_loc(x))
+    CALL bar(c_loc(x), n)
+  !$omp end target data
+  CALL bar_device_addr(x,n)
+  !$omp target exit data map(from: x)
+  CALL print_ptr(c_loc(x))
+  DO i = 1,n
+     IF (x(i) .ne. 3) then
+       PRINT *, "Bad result for use_device_addr!"
+       STOP 1
+     ENDIF
+  END DO
+  DEALLOCATE(x)
+  write(error_unit, *) 'Success'
+END PROGRAM test_ptr
+


### PR DESCRIPTION
Flang should emit only two map entries: the descriptor for x and the allocation that holds x’s data. Using `use_device_addr` must not add any further map entries.