### PR TITLE
[UMT] Use release tag for CONDUIT

### DIFF
--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -104,7 +104,7 @@ if [ "$1" == "build_umt" ]; then
     popd
 
     pushd $AOMP_REPOS_TEST/$CONDUIT_SRC_DIR
-    git clone https://github.com/LLNL/conduit.git .
+    git clone --branch v0.9.6 https://github.com/LLNL/conduit.git .
     rm -rf build
     mkdir build
     pushd build


### PR DESCRIPTION
   - avoids error needing newer cmake 3.26