### PR TITLE
Upgrade cmake version from 3.25.2 to 3.31.0

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -688,7 +688,7 @@ function buildfftw(){
 
 function buildcmake(){
   _cname="cmake"
-  _version=3.25.2
+  _version=3.31.0
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname 


### PR DESCRIPTION
Upgrading the version of cmake to be able to build new version of HDF5 and going forward LLVM 24.0 / 25.0 will need cmake version of minimum 3.31.0