### PR TITLE
[OMPT] Update veccopy EMI/non-EMI tests

### DIFF
--- a/test/smoke-dev/veccopy-ompt-target-disallow-both/veccopy-ompt-target-disallow-both.c
+++ b/test/smoke-dev/veccopy-ompt-target-disallow-both/veccopy-ompt-target-disallow-both.c
@@ -45,7 +45,11 @@ int main()
 
   /// CHECK: Callback Init:
   /// CHECK: Callback Load:
-  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
@@ -63,8 +67,8 @@ int main()
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
-  /// CHECK: Callback Target EMI: kind=1 endpoint=2
-  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
@@ -82,5 +86,5 @@ int main()
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
   /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
   /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
-  /// CHECK: Callback Target EMI: kind=1 endpoint=2
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
   /// CHECK: Callback Fini:


### PR DESCRIPTION
Updates a downstream test to changes upstream.
Upstream also has this test (basically), so we will converge to remove the downstream-only test at some point.