### PR TITLE
[test] duplicate check-xnack , some scripts want it in smok-dev

### DIFF
--- a/test/smoke-dev/check-xnack/Makefile
+++ b/test/smoke-dev/check-xnack/Makefile
@@ -1,0 +1,22 @@
+include ../../Makefile.defs
+
+TESTNAME     = check-xnack
+TESTSRC_MAIN = check-xnack.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += HSA_XNACK=1 OMPX_APU_MAPS=1
+
+RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU) -I$(AOMP)/include -I$(AOMP)/../../include  -L$(AOMP)/lib -L$(AOMPHIP)/lib -lhsa-runtime64 -Wl,-rpath,$(AOMPHIP)/lib
+CFLAGS       += -O3
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/check-xnack/check-xnack.cpp
+++ b/test/smoke-dev/check-xnack/check-xnack.cpp
@@ -1,0 +1,19 @@
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+#include <iostream>
+
+void f() {
+  bool hasSystemXnackEnabled = false;
+  hsa_status_t HsaStatus = hsa_system_get_info(
+      HSA_AMD_SYSTEM_INFO_XNACK_ENABLED, &hasSystemXnackEnabled);
+  if (HsaStatus != HSA_STATUS_SUCCESS)
+    printf("Output status is bad!\n");
+  printf("hasSystemXnackEnabled = %d\n", hasSystemXnackEnabled);
+}
+
+int main() {
+  // CHECK-NOT: Output status is bad!
+  // CHECK: hasSystemXnackEnabled = 1
+  f();
+  return 0;
+}


### PR DESCRIPTION
 some psdb scripts want a check-xnack in smoke-dev