### PR TITLE
[CI][CK] Fix exported PATH to cover ROCM_PATH/bin directory

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -30,8 +30,6 @@ thisdir=$(dirname "$realpath")
 # shellcheck disable=SC1091
 . "$thisdir"/aomp_common_vars
 
-export PATH=$AOMP/bin:$PATH
-
 function printHelp {
   set +x
   echo "Usage: run_composable-kernels.sh"
@@ -255,9 +253,11 @@ done
 : "${CK_CLIENT_EXAMPLES_TO_EXCLUDE:=""}"
 
 # Get some info on the system
-: "${ROCM_PATH:=/opt/rocm}"
+: "${ROCM_PATH:=$(realpath -m "${AOMP}/../..")}"
 : "${CK_GPU_TARGETS:=""}"
 : "${AOMP_LIB_PATH:="${AOMP}/.."}"
+
+export PATH="${AOMP}/bin:${ROCM_PATH}/bin:${PATH}"
 
 if [ -z "${CK_GPU_TARGETS}" ]; then
   # First check AOMP_GPU to see if the user has set a target GPU architecture.


### PR DESCRIPTION
amd-smi call could generate an error due to binary/library mismatch:
```
AttributeError: .../libamd_smi.so: undefined symbol: amdsmi_set_gpu_clk_range.
                Did you mean: 'amdsmi_get_gpu_fan_rpms'?
```

## Motivation

Fix error when e.g. performing client-examples run.

## Technical Details

Aligning binary/library via PATH.
(Alternatively we could use PYTHONPATH.)

## Test Plan

Perform CI CK-client-examples run on previously failing system.

## Test Result

Successful run confirmed via generated report.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
