### PR TITLE
[Build] Centralize component source roots via env vars

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -435,6 +435,22 @@ fi
 #  These aomp development repositories
 AOMP_REPO_NAME=${AOMP_REPO_NAME:-aomp}
 
+# Centralized source roots for the interdependent components that a developer may
+# check out per task (e.g. in a dedicated worktree). The build_* scripts read
+# their sources from these variables instead of hardcoding $AOMP_REPOS/<name>, so
+# a single environment override redirects a component's source without moving the
+# shared checkout of all the other components. Defaults preserve the historical
+# $AOMP_REPOS/<name> layout, so unset behavior is unchanged.
+#   AOMP_PROJECT_SRC : the llvm-project monorepo root (also holds amd/comgr,
+#                      amd/device-libs, amd/hipcc, offload, openmp, runtimes).
+#   AOMP_SPIRV_SRC   : the SPIRV-LLVM-Translator source, built as an LLVM
+#                      external project by build_project.sh.
+#   AOMP_SRC         : the aomp repo root (build scripts, examples, Makefile).
+AOMP_PROJECT_SRC=${AOMP_PROJECT_SRC:-$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME}
+AOMP_SPIRV_SRC=${AOMP_SPIRV_SRC:-$AOMP_REPOS/SPIRV-LLVM-Translator}
+AOMP_SRC=${AOMP_SRC:-$AOMP_REPOS/$AOMP_REPO_NAME}
+export AOMP_PROJECT_SRC AOMP_SPIRV_SRC AOMP_SRC
+
 #  These extra repositories are needed but we cannot update them
 AOMP_ROCM_SYSTEMS_NAME=${AOMP_ROCM_SYSTEMS_NAME:-rocm-systems/projects}
 AOMP_ROCT_REPO_NAME=${AOMP_ROCT_REPO_NAME:-roct-thunk-interface}

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -24,14 +24,14 @@ function build_aomp_component() {
    start_date=$(date)
    start_secs=$(date +%s)
 
-   "$AOMP_REPOS/$AOMP_REPO_NAME/bin/build_$COMPONENT.sh" "$@"
+   "$AOMP_SRC/bin/build_$COMPONENT.sh" "$@"
    rc=$?
    if [ $rc != 0 ] ; then 
       echo " !!!  build_aomp.sh: BUILD FAILED FOR COMPONENT $COMPONENT !!!"
       exit $rc
    fi  
    if [ $# -eq 0 ] ; then
-       "$AOMP_REPOS/$AOMP_REPO_NAME/bin/build_$COMPONENT.sh" install
+       "$AOMP_SRC/bin/build_$COMPONENT.sh" install
        rc=$?
        if [ $rc != 0 ] ; then 
            echo " !!!  build_aomp.sh: INSTALL FAILED FOR COMPONENT $COMPONENT !!!"
@@ -188,7 +188,7 @@ for COMPONENT in $components ; do
 done
 
 #Run build_fixups.sh to clean the AOMP directory before packaging
-#$AOMP_REPOS/$AOMP_REPO_NAME/bin/build_fixups.sh
+#$AOMP_SRC/bin/build_fixups.sh
 echo 
 date
 echo " =================  END build_aomp.sh ==================="   

--- a/bin/build_comgr.sh
+++ b/bin/build_comgr.sh
@@ -11,12 +11,12 @@ thisdir=$(dirname "$realpath")
 
 INSTALL_COMGR=${INSTALL_COMGR:-$AOMP_INSTALL_DIR}
 
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME
 
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   echo " "
   echo " This script builds the code object manager"
-  echo " It gets the source from:  $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"
+  echo " It gets the source from:  $AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"
   echo " It builds libraries in:   $BUILD_AOMP/build/comgr"
   echo " It installs in:           $INSTALL_COMGR"
   echo " "
@@ -30,8 +30,8 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   exit 
 fi
 
-if [ ! -d "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME" ] ; then
-   echo "ERROR:  Missing repository $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"
+if [ ! -d "$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME" ] ; then
+   echo "ERROR:  Missing repository $AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"
    echo "        Are environment variables AOMP_REPOS and AOMP_COMGR_REPO_NAME set correctly?"
    exit 1
 fi
@@ -65,7 +65,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo " -----Running comgr cmake ---- " 
 
    DEVICELIBS_BUILD_PATH=$AOMP_REPOS/build/AOMP_LIBDEVICE_REPO_NAME
-   PACKAGE_ROOT=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME
+   PACKAGE_ROOT=$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME
    COMMON_PREFIX_PATH="$AOMP/include/amd_comgr;$DEVICELIBS_BUILD_PATH;$PACKAGE_ROOT;$LLVM_INSTALL_LOC"
    MYCMAKEOPTS=(
       -DCMAKE_INSTALL_PREFIX="$INSTALL_COMGR"
@@ -77,12 +77,12 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
       -DCMAKE_PREFIX_PATH="$AOMP/lib/cmake;$COMMON_PREFIX_PATH" \
       -DCMAKE_INSTALL_LIBDIR=lib "${AOMP_ORIGIN_RPATH[@]}" \
-      "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"
+      "$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"
 
    if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
           -DCMAKE_PREFIX_PATH="$AOMP/lib/cmake;$COMMON_PREFIX_PATH" \
           -DCMAKE_INSTALL_LIBDIR=lib "${AOMP_ORIGIN_RPATH[@]}" \
-          "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"; then
+          "$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"; then
       echo "ERROR comgr cmake failed. cmake flags"
       exit 1
    fi
@@ -99,14 +99,14 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
         -DCMAKE_INSTALL_LIBDIR=lib/asan "$(shquot "${AOMP_ASAN_ORIGIN_RPATH[@]}")" \
         -DCMAKE_C_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
         -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
-        "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"
+        "$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"
 
       if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
             -DCMAKE_PREFIX_PATH="$AOMP/lib/asan/cmake;$COMMON_PREFIX_PATH;$AOMP/lib/cmake" \
             -DCMAKE_INSTALL_LIBDIR=lib/asan "${AOMP_ASAN_ORIGIN_RPATH[@]}" \
             -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
             -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
-            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_COMGR_REPO_NAME"; then
+            "$AOMP_PROJECT_SRC/amd/$AOMP_COMGR_REPO_NAME"; then
          echo "ERROR comgr-asan cmake failed. cmake flags"
          exit 1
       fi

--- a/bin/build_emissary.sh
+++ b/bin/build_emissary.sh
@@ -118,7 +118,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   MYCMAKEOPTS=(
     -DCMAKE_BUILD_TYPE="$BUILDTYPE"
     "${extra_cmake_opts[@]}"
-    "-DLLVM_MAIN_SRC_DIR=$AOMP_REPOS/llvm-project"
+    "-DLLVM_MAIN_SRC_DIR=$AOMP_PROJECT_SRC"
     -DCMAKE_INSTALL_PREFIX="$INSTALL_EMISSARY")
 
 

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -35,7 +35,7 @@ thisdir=$(dirname "$realpath")
 . "$thisdir/aomp_common_vars"
 # --- end standard header ----
 
-AOMP_REPO_DIR=$AOMP_REPOS/$AOMP_REPO_NAME
+AOMP_REPO_DIR=$AOMP_SRC
 
 BUILD_DIR=${BUILD_AOMP}
 
@@ -85,7 +85,7 @@ if [ "$1" != "install" ] ; then
 
   echo "----- Copy util scripts to $BUILD_DIR/build/extras -----"
   cp "$AOMP_REPO_DIR"/utils/* "$BUILD_DIR"/build/extras
-  cp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME"/offload/utils/gpurun "$BUILD_DIR"/build/extras
+  cp "$AOMP_PROJECT_SRC"/offload/utils/gpurun "$BUILD_DIR"/build/extras
 
   for util in $install_list; do
     if [ "$util" == "rebundle_hip_lib.sh" ]; then

--- a/bin/build_fixups.sh
+++ b/bin/build_fixups.sh
@@ -14,15 +14,15 @@ thisdir=$(dirname "$realpath")
 if [ -d "$AOMP/examples" ]; then
   $SUDO rm -rf "$AOMP/examples"
 fi
-echo $SUDO cp -rp "$AOMP_REPOS/$AOMP_REPO_NAME/examples" "$AOMP"
-$SUDO cp -rp "$AOMP_REPOS/$AOMP_REPO_NAME/examples" "$AOMP"
+echo $SUDO cp -rp "$AOMP_SRC/examples" "$AOMP"
+$SUDO cp -rp "$AOMP_SRC/examples" "$AOMP"
 
 if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
   # Licenses
   echo mkdir -p "$AOMP/share/doc/aomp"
   mkdir -p "$AOMP/share/doc/aomp"
-  echo $SUDO cp "$AOMP_REPOS/$AOMP_REPO_NAME/LICENSE" "$AOMP/share/doc/aomp/LICENSE.apache2"
-  $SUDO cp "$AOMP_REPOS/$AOMP_REPO_NAME/LICENSE" "$AOMP/share/doc/aomp/LICENSE.apache2"
+  echo $SUDO cp "$AOMP_SRC/LICENSE" "$AOMP/share/doc/aomp/LICENSE.apache2"
+  $SUDO cp "$AOMP_SRC/LICENSE" "$AOMP/share/doc/aomp/LICENSE.apache2"
   echo $SUDO cp "$AOMP_REPOS/$AOMP_EXTRAS_REPO_NAME/LICENSE" "$AOMP/share/doc/aomp/LICENSE.mit"
   $SUDO cp "$AOMP_REPOS/$AOMP_EXTRAS_REPO_NAME/LICENSE" "$AOMP/share/doc/aomp/LICENSE.mit"
   echo $SUDO cp "$AOMP_REPOS/$AOMP_FLANG_REPO_NAME/LICENSE.txt" "$AOMP/share/doc/aomp/LICENSE.flang"

--- a/bin/build_hipcc.sh
+++ b/bin/build_hipcc.sh
@@ -29,7 +29,7 @@ thisdir=$(dirname "$realpath")
 . "$thisdir/aomp_common_vars"
 # --- end standard header ----
 
-HIPCC_REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/hipcc
+HIPCC_REPO_DIR=$AOMP_PROJECT_SRC/amd/hipcc
 
 BUILD_DIR=${BUILD_AOMP}
 

--- a/bin/build_libdevice.sh
+++ b/bin/build_libdevice.sh
@@ -21,7 +21,7 @@ INSTALL_DIR=$INSTALL_ROOT_DIR
 export LLVM_DIR=$AOMP_INSTALL_DIR
 export LLVM_BUILD=$AOMP_INSTALL_DIR
 
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_LIBDEVICE_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC/amd/$AOMP_LIBDEVICE_REPO_NAME
 
 declare -a MYCMAKEOPTS
 
@@ -56,11 +56,11 @@ if [ "$1" != "install" ] && [ "$1" != "nocmake" ]; then
       export CC
       echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
            "-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR" \
-           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_LIBDEVICE_REPO_NAME"
+           "$AOMP_PROJECT_SRC/amd/$AOMP_LIBDEVICE_REPO_NAME"
 
       if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
                          -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/$AOMP_LIBDEVICE_REPO_NAME"; then 
+                         "$AOMP_PROJECT_SRC/amd/$AOMP_LIBDEVICE_REPO_NAME"; then 
          echo "ERROR cmake failed  command was:"
          echo "      ${AOMP_CMAKE} $(shquot "${MYCMAKEOPTS[@]}") -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $BUILD_DIR/$AOMP_LIBDEVICE_REPO_NAME"
          exit 1

--- a/bin/build_llvm_runtimes_standalone.sh
+++ b/bin/build_llvm_runtimes_standalone.sh
@@ -14,7 +14,7 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC
 _ompd_src_dir="$LLVM_INSTALL_LOC/share/gdb/python/ompd/src"
 OPENMP_BUILD_DEVICERTL=${OPENMP_BUILD_DEVICERTL:-0}
 RUNTIMES_BUILD_DIR=${RUNTIMES_BUILD_DIR:-"llvm_runtimes_standalone"}
@@ -36,8 +36,8 @@ if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    export CUDAFE_FLAGS="-w"
 fi
 
-if [ ! -d "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME" ] ; then
-   echo "ERROR:  Missing repository $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME "
+if [ ! -d "$AOMP_PROJECT_SRC" ] ; then
+   echo "ERROR:  Missing repository $AOMP_PROJECT_SRC "
    echo "        Consider setting env variables AOMP_REPOS and/or AOMP_PROJECT_REPO_NAME "
    exit 1
 fi
@@ -81,7 +81,7 @@ COMMON_CMAKE_OPTS=("${AOMP_SET_NINJA_GEN[@]}" -DOPENMP_ENABLE_LIBOMPTARGET=1
 
 LLVM_RUNTIMES="openmp;offload"
 if [ "$OPENMP_BUILD_DEVICERTL" -eq 1 ]; then
-  if [ -f "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/CMakeLists.txt" ]; then
+  if [ -f "$AOMP_PROJECT_SRC/openmp/device/CMakeLists.txt" ]; then
     LLVM_RUNTIMES=openmp
     COMMON_CMAKE_OPTS=("${COMMON_CMAKE_OPTS[@]}"
                        -DLLVM_DEFAULT_TARGET_TRIPLE=amdgcn-amd-amdhsa
@@ -108,9 +108,9 @@ if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
                      -DCMAKE_MODULE_PATH="$LLVM_PROJECT_ROOT/llvm/cmake/modules")
 else
   COMMON_CMAKE_OPTS=("${COMMON_CMAKE_OPTS[@]}"
-                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include"
-                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include"
-                     -DCMAKE_MODULE_PATH="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/cmake/modules"
+                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_PROJECT_SRC/llvm/include"
+                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_PROJECT_SRC/llvm/include"
+                     -DCMAKE_MODULE_PATH="$AOMP_PROJECT_SRC/llvm/cmake/modules"
                      -DLLVM_INSTALL_PREFIX="$LLVM_INSTALL_LOC")
 fi
 
@@ -193,13 +193,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                              -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                              -DOFFLOAD_LIBDIR_SUFFIX="/asan" \
                              -DLLVM_LIBDIR_SUFFIX="/asan" \
-                             "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"
+                             "$AOMP_PROJECT_SRC/runtimes"
         if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                            -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DOFFLOAD_LIBDIR_SUFFIX="/asan" \
                            -DLLVM_LIBDIR_SUFFIX="/asan" \
-                           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"; then
+                           "$AOMP_PROJECT_SRC/runtimes"; then
            echo "ERROR llvm_runtimes_standalone cmake failed. Cmake flags"
            echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
            exit 1
@@ -219,11 +219,11 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
     cd "$BUILD_DIR/build/${RUNTIMES_BUILD_DIR}_perf" || exit
     echo " -----Running llvm_runtimes_standalone cmake for perf ---- "
     echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes" \
+                         "$AOMP_PROJECT_SRC/runtimes" \
                          "$(shquot "${AOMP_ORIGIN_RPATH[@]}")"
 
     if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
-                       "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes" \
+                       "$AOMP_PROJECT_SRC/runtimes" \
                        "${AOMP_ORIGIN_RPATH[@]}"; then
        echo "error llvm_runtimes_standalone cmake failed. cmake flags"
        echo "      $(shquot "${MYCMAKEOPTS[@]}")"
@@ -245,14 +245,14 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                             -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-perf/asan" \
                             -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"
+                            "$AOMP_PROJECT_SRC/runtimes"
 
        if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                           -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DOFFLOAD_LIBDIR_SUFFIX="-perf/asan" \
                           -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                          "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"; then
+                          "$AOMP_PROJECT_SRC/runtimes"; then
           echo "error llvm_runtimes_standalone cmake failed. cmake flags"
           echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
           exit 1
@@ -261,7 +261,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   fi
 
    if [ "$AOMP_BUILD_DEBUG" == "1" ] ; then
-      _prefix_map=(-fdebug-prefix-map="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload=$_ompd_src_dir/offload")
+      _prefix_map=(-fdebug-prefix-map="$AOMP_PROJECT_SRC/offload=$_ompd_src_dir/offload")
 
       declare -a DEBUGCMAKEOPTS
 
@@ -314,7 +314,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                             -DCMAKE_CXX_FLAGS="$CXXFLAGS -g $(cmquot "${_prefix_map[@]}")" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-debug" \
                             -DLLVM_LIBDIR_SUFFIX="-debug" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"; then
+                            "$AOMP_PROJECT_SRC/runtimes"; then
             echo "ERROR llvm_runtimes_standalone debug cmake failed. Cmake flags"
             echo "      $(shquot "${MYCMAKEOPTS[@]}")"
             exit 1
@@ -341,14 +341,14 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                               -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                               -DOFFLOAD_LIBDIR_SUFFIX="-debug/asan" \
                               -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                              "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"
+                              "$AOMP_PROJECT_SRC/runtimes"
 
          if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                             -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-debug/asan" \
                             -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/runtimes"; then
+                            "$AOMP_PROJECT_SRC/runtimes"; then
             echo "ERROR llvm_runtimes_standalone debug cmake failed. Cmake flags"
             echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
             exit 1
@@ -491,8 +491,8 @@ if [ "$1" == "install" ] ; then
     $SUDO mkdir -p "$_ompd_src_dir/offload"
     $SUDO mkdir -p "$_ompd_src_dir/offload/plugins-nextgen"
     if [ "$AOMP_STANDALONE_BUILD" == 1 ]; then
-       _from_dir_src="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload/libomptarget"
-       _from_dir_plugins="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload/plugins-nextgen"
+       _from_dir_src="$AOMP_PROJECT_SRC/offload/libomptarget"
+       _from_dir_plugins="$AOMP_PROJECT_SRC/offload/plugins-nextgen"
     else
        _from_dir_src="$LLVM_PROJECT_ROOT/offload/libomptarget"
        _from_dir_plugins="$LLVM_PROJECT_ROOT/offload/plugins-nextgen"
@@ -508,9 +508,9 @@ if [ "$1" == "install" ] ; then
     $SUDO mkdir -p "$_ompd_src_dir/openmp/libompd"
     $SUDO mkdir -p "$_ompd_src_dir/openmp/device"
     if [ "$AOMP_STANDALONE_BUILD" == 1 ]; then
-      $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
-      $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"
-      $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/src" "$_ompd_src_dir/openmp/device"
+      $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
+      $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"
+      $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/device/src" "$_ompd_src_dir/openmp/device"
     else
       $SUDO cp -rp "$LLVM_PROJECT_ROOT/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
       $SUDO cp -rp "$LLVM_PROJECT_ROOT/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"

--- a/bin/build_offload.sh
+++ b/bin/build_offload.sh
@@ -14,7 +14,7 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC
 _ompd_src_dir="$LLVM_INSTALL_LOC/share/gdb/python/ompd/src"
 
 if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
@@ -34,8 +34,8 @@ if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    export CUDAFE_FLAGS="-w"
 fi
 
-if [ ! -d "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME" ] ; then
-   echo "ERROR:  Missing repository $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME "
+if [ ! -d "$AOMP_PROJECT_SRC" ] ; then
+   echo "ERROR:  Missing repository $AOMP_PROJECT_SRC "
    echo "        Consider setting env variables AOMP_REPOS and/or AOMP_PROJECT_REPO_NAME "
    exit 1
 fi
@@ -77,8 +77,8 @@ if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
                      -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$LLVM_PROJECT_ROOT/llvm/include")
 else
   COMMON_CMAKE_OPTS=("${COMMON_CMAKE_OPTS[@]}"
-                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include"
-                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include")
+                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_PROJECT_SRC/llvm/include"
+                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_PROJECT_SRC/llvm/include")
 fi
 
 if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
@@ -135,10 +135,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       mkdir -p "$BUILD_DIR/build/offload"
       cd "$BUILD_DIR/build/offload" || exit
       echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
-                           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"
+                           "$AOMP_PROJECT_SRC/offload"
 
       if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"; then
+                         "$AOMP_PROJECT_SRC/offload"; then
          echo "ERROR offload cmake failed. Cmake flags"
          echo "      $(shquot "${MYCMAKEOPTS[@]}")"
          exit 1
@@ -166,13 +166,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                              -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                              -DOFFLOAD_LIBDIR_SUFFIX="/asan" \
                              -DLLVM_LIBDIR_SUFFIX="/asan" \
-                             "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"
+                             "$AOMP_PROJECT_SRC/offload"
         if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                            -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DOFFLOAD_LIBDIR_SUFFIX="/asan" \
                            -DLLVM_LIBDIR_SUFFIX="/asan" \
-                           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"; then
+                           "$AOMP_PROJECT_SRC/offload"; then
            echo "ERROR offload cmake failed. Cmake flags"
            echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
            exit 1
@@ -192,11 +192,11 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
     cd "$BUILD_DIR/build/offload_perf" || exit
     echo " -----Running offload cmake for perf ---- "
     echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload" \
+                         "$AOMP_PROJECT_SRC/offload" \
                          "$(shquot "${AOMP_ORIGIN_RPATH[@]}")"
 
     if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
-                       "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload" \
+                       "$AOMP_PROJECT_SRC/offload" \
                        "${AOMP_ORIGIN_RPATH[@]}"; then
        echo "error offload cmake failed. cmake flags"
        echo "      $(shquot "${MYCMAKEOPTS[@]}")"
@@ -218,14 +218,14 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                             -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-perf/asan" \
                             -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"
+                            "$AOMP_PROJECT_SRC/offload"
 
        if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                           -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DOFFLOAD_LIBDIR_SUFFIX="-perf/asan" \
                           -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                          "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"; then
+                          "$AOMP_PROJECT_SRC/offload"; then
           echo "error offload cmake failed. cmake flags"
           echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
           exit 1
@@ -234,7 +234,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   fi
 
    if [ "$AOMP_BUILD_DEBUG" == "1" ] ; then
-      _prefix_map=(-fdebug-prefix-map="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload=$_ompd_src_dir/offload")
+      _prefix_map=(-fdebug-prefix-map="$AOMP_PROJECT_SRC/offload=$_ompd_src_dir/offload")
 
       declare -a DEBUGCMAKEOPTS
 
@@ -287,7 +287,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                             -DCMAKE_CXX_FLAGS="$CXXFLAGS -g $(cmquot "${_prefix_map[@]}")" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-debug" \
                             -DLLVM_LIBDIR_SUFFIX="-debug" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"; then
+                            "$AOMP_PROJECT_SRC/offload"; then
             echo "ERROR offload debug cmake failed. Cmake flags"
             echo "      $(shquot "${MYCMAKEOPTS[@]}")"
             exit 1
@@ -314,14 +314,14 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                               -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                               -DOFFLOAD_LIBDIR_SUFFIX="-debug/asan" \
                               -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                              "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"
+                              "$AOMP_PROJECT_SRC/offload"
 
          if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                             -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DOFFLOAD_LIBDIR_SUFFIX="-debug/asan" \
                             -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload"; then
+                            "$AOMP_PROJECT_SRC/offload"; then
             echo "ERROR offload debug cmake failed. Cmake flags"
             echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
             exit 1
@@ -488,8 +488,8 @@ if [ "$1" == "install" ] ; then
       $SUDO mkdir -p "$_ompd_src_dir/offload"
       $SUDO mkdir -p "$_ompd_src_dir/offload/plugins-nextgen"
       if [ "$AOMP_STANDALONE_BUILD" == 1 ]; then
-         _from_dir_src="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload/libomptarget"
-         _from_dir_plugins="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/offload/plugins-nextgen"
+         _from_dir_src="$AOMP_PROJECT_SRC/offload/libomptarget"
+         _from_dir_plugins="$AOMP_PROJECT_SRC/offload/plugins-nextgen"
       else
          _from_dir_src="$LLVM_PROJECT_ROOT/offload/libomptarget"
          _from_dir_plugins="$LLVM_PROJECT_ROOT/offload/plugins-nextgen"

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -14,7 +14,7 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC
 _ompd_src_dir="$LLVM_INSTALL_LOC/share/gdb/python/ompd/src"
 _ompd_dir="$LLVM_INSTALL_LOC/share/gdb/python/ompd"
 OPENMP_BUILD_DEVICERTL=${OPENMP_BUILD_DEVICERTL:-0}
@@ -37,8 +37,8 @@ if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    export CUDAFE_FLAGS="-w"
 fi
 
-if [ ! -d "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME" ] ; then
-  echo "ERROR:  Missing repository $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME "
+if [ ! -d "$AOMP_PROJECT_SRC" ] ; then
+  echo "ERROR:  Missing repository $AOMP_PROJECT_SRC "
   echo "        Consider setting env variables AOMP_REPOS and/or AOMP_PROJECT_REPO_NAME "
   exit 1
 fi
@@ -76,7 +76,7 @@ COMMON_CMAKE_OPTS=("${AOMP_SET_NINJA_GEN[@]}" -DOPENMP_ENABLE_LIBOMPTARGET=1
                    -DLLVM_DIR="$LLVM_DIR")
 
 if [ "$OPENMP_BUILD_DEVICERTL" -eq 1 ]; then
-  if [ -f "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/CMakeLists.txt" ]; then
+  if [ -f "$AOMP_PROJECT_SRC/openmp/device/CMakeLists.txt" ]; then
     COMMON_CMAKE_OPTS=("${COMMON_CMAKE_OPTS[@]}"
                        -DLLVM_DEFAULT_TARGET_TRIPLE=amdgcn-amd-amdhsa)
   fi
@@ -94,8 +94,8 @@ if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
                      -DAOMP_STANDALONE_BUILD="$AOMP_STANDALONE_BUILD")
 else
   COMMON_CMAKE_OPTS=("${COMMON_CMAKE_OPTS[@]}"
-                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include"
-                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/include"
+                     -DLLVM_MAIN_INCLUDE_DIR="$AOMP_PROJECT_SRC/llvm/include"
+                     -DLIBOMPTARGET_LLVM_INCLUDE_DIRS="$AOMP_PROJECT_SRC/llvm/include"
                      -DLIBOMP_USE_HWLOC=ON
                      -DLIBOMP_HWLOC_INSTALL_DIR="$AOMP_SUPP/hwloc")
 fi
@@ -170,10 +170,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       mkdir -p "$BUILD_DIR/build/$OPENMP_BUILD_DIR"
       cd "$BUILD_DIR/build/$OPENMP_BUILD_DIR" || exit
       echo "${AOMP_CMAKE}" "${MYCMAKEOPTS[@]}" \
-                           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                           "$AOMP_PROJECT_SRC/openmp"
 
       if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                         "$AOMP_PROJECT_SRC/openmp"; then
          echo "ERROR openmp cmake failed. Cmake flags"
          echo "      $(shquot "${MYCMAKEOPTS[@]}")"
          exit 1
@@ -201,13 +201,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                              -DCMAKE_C_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                              -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                              -DLLVM_LIBDIR_SUFFIX="/asan" \
-                             "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                             "$AOMP_PROJECT_SRC/openmp"
 
         if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                            -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                            -DLLVM_LIBDIR_SUFFIX="/asan" \
-                           "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                           "$AOMP_PROJECT_SRC/openmp"; then
            echo "ERROR openmp cmake failed. Cmake flags"
            echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
            exit 1
@@ -227,12 +227,12 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
     echo "${AOMP_CMAKE}" "$(shquot "${MYCMAKEOPTS[@]}")" \
                          -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR/lib/cmake" \
                          "$(shquot "${AOMP_ORIGIN_RPATH[@]}")" \
-                         "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                         "$AOMP_PROJECT_SRC/openmp"
 
     if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" \
                        -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR/lib/cmake" \
                        "${AOMP_ORIGIN_RPATH[@]}" \
-                       "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                       "$AOMP_PROJECT_SRC/openmp"; then
        echo "error openmp cmake failed. cmake flags"
        echo "      $(shquot "${MYCMAKEOPTS[@]}")"
        exit 1
@@ -251,7 +251,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                             -DCMAKE_C_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                             -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                             -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                            "$AOMP_PROJECT_SRC/openmp"
 
        if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                           -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR/lib/asan/cmake;$AOMP_INSTALL_DIR/lib/cmake/AMDDeviceLibs" \
@@ -259,7 +259,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                           -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                           -DLLVM_LIBDIR_SUFFIX="-perf/asan" \
-                          "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                          "$AOMP_PROJECT_SRC/openmp"; then
           echo "error openmp cmake failed. cmake flags"
           echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
           exit 1
@@ -283,7 +283,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                       -DLIBOMP_CPPFLAGS='-O0'
                       -DLIBOMP_OMPD_SUPPORT=ON
                       -DLIBOMP_OMPT_DEBUG=ON
-                      -DOPENMP_SOURCE_DEBUG_MAP="-fdebug-prefix-map=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp=$_ompd_src_dir/openmp")
+                      -DOPENMP_SOURCE_DEBUG_MAP="-fdebug-prefix-map=$AOMP_PROJECT_SRC/openmp=$_ompd_src_dir/openmp")
 
       # The 'pip install --system' command is not supported on non-debian systems. This will disable
       # the system option if the debian_version file is not present.
@@ -317,13 +317,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                               -DCMAKE_C_FLAGS="$CFLAGS -g" \
                               -DCMAKE_CXX_FLAGS="$CXXFLAGS -g" \
                               -DLLVM_LIBDIR_SUFFIX=-debug \
-                              "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                              "$AOMP_PROJECT_SRC/openmp"
 
          if ! ${AOMP_CMAKE} "${MYCMAKEOPTS[@]}" "$PREFIX_PATH" \
                             -DCMAKE_C_FLAGS="$CFLAGS -g" \
                             -DCMAKE_CXX_FLAGS="$CXXFLAGS -g" \
                             -DLLVM_LIBDIR_SUFFIX=-debug \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                            "$AOMP_PROJECT_SRC/openmp"; then
             echo "ERROR openmp debug cmake failed. Cmake flags"
             echo "      $(shquot "${MYCMAKEOPTS[@]}")"
             exit 1
@@ -350,13 +350,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                               -DCMAKE_C_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                               -DCMAKE_CXX_FLAGS="\"$(cmquot "${ASAN_FLAGS[@]}")\"" \
                               -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                              "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"
+                              "$AOMP_PROJECT_SRC/openmp"
 
          if ! ${AOMP_CMAKE} "${ASAN_CMAKE_OPTS[@]}" \
                             -DCMAKE_C_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DCMAKE_CXX_FLAGS="$(cmquot "${ASAN_FLAGS[@]}")" \
                             -DLLVM_LIBDIR_SUFFIX="-debug/asan" \
-                            "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp"; then
+                            "$AOMP_PROJECT_SRC/openmp"; then
             echo "ERROR openmp debug cmake failed. Cmake flags"
             echo "      $(shquot "${ASAN_CMAKE_OPTS[@]}")"
             exit 1
@@ -541,9 +541,9 @@ if [ "$1" == "install" ] ; then
       $SUDO mkdir -p "$_ompd_src_dir/openmp/libompd"
       $SUDO mkdir -p "$_ompd_src_dir/openmp/device"
       if [ "$AOMP_STANDALONE_BUILD" == 1 ]; then
-        $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
-        $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"
-        $SUDO cp -rp "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/src" "$_ompd_src_dir/openmp/device"
+        $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
+        $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"
+        $SUDO cp -rp "$AOMP_PROJECT_SRC/openmp/device/src" "$_ompd_src_dir/openmp/device"
       else
         $SUDO cp -rp "$LLVM_PROJECT_ROOT/openmp/runtime/src" "$_ompd_src_dir/openmp/runtime"
         $SUDO cp -rp "$LLVM_PROJECT_ROOT/openmp/libompd/src" "$_ompd_src_dir/openmp/libompd"

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -25,7 +25,7 @@ WEBSITE="http\:\/\/github.com\/ROCm\/aomp"
 # WARNING: This patch (ATD_ASO_full.patch) rarely applies cleanly
 #          because of its size and constant trunk merges to amd-staging.
 #          This is why default is 0 (OFF).
-REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
+REPO_DIR=$AOMP_PROJECT_SRC
 if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH" == 1 ] ; then
    patchrepo "$REPO_DIR"
 fi
@@ -124,9 +124,9 @@ MYCMAKEOPTS=(-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
              -DLLVM_BUILD_LLVM_DYLIB=ON
              -DLLVM_LINK_LLVM_DYLIB=ON
              -DCLANG_LINK_CLANG_DYLIB=ON
-             -DLIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/device-libs"
+             -DLIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH="$AOMP_PROJECT_SRC/amd/device-libs"
              -DLLVM_EXTERNAL_PROJECTS=SPIRV_TRANSLATOR
-             -DLLVM_EXTERNAL_SPIRV_TRANSLATOR_SOURCE_DIR="$AOMP_REPOS/SPIRV-LLVM-Translator"
+             -DLLVM_EXTERNAL_SPIRV_TRANSLATOR_SOURCE_DIR="$AOMP_SPIRV_SRC"
              -DROCM_DEVICE_LIBS_INSTALL_PREFIX_PATH="$AOMP_INSTALL_DIR"
              -DROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC="$rocmdevicelib_loc_new"
              -DLIBOMP_COPY_EXPORTS=OFF
@@ -143,7 +143,7 @@ MYCMAKEOPTS=(-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
              -DLIBOMPTARGET_BUILD_DEVICE_FORTRT=On
              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)
 
-if [ -f "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/CMakeLists.txt" ]; then
+if [ -f "$AOMP_PROJECT_SRC/openmp/device/CMakeLists.txt" ]; then
   MYCMAKEOPTS=("${MYCMAKEOPTS[@]}"
                -DLLVM_RUNTIME_TARGETS='default;amdgcn-amd-amdhsa'
                -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;flang-rt;openmp'
@@ -164,14 +164,14 @@ MYCMAKEOPTS=("${MYCMAKEOPTS[@]}"
              -DLLVM_RUNTIME_TARGETS="default;amdgcn-amd-amdhsa"
              -DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBC_PROVIDER=llvm
              -DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBCXX_PROVIDER=llvm
-             -DRUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/compiler-rt/cmake/caches/AMDGPU.cmake;$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/libcxx/cmake/caches/AMDGPU.cmake"
+             -DRUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES="$AOMP_PROJECT_SRC/compiler-rt/cmake/caches/AMDGPU.cmake;$AOMP_PROJECT_SRC/libcxx/cmake/caches/AMDGPU.cmake"
              )
 
 # Enable Compiler-rt Sanitizer Build
 if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
     MYCMAKEOPTS=("${MYCMAKEOPTS[@]}" -DSANITIZER_AMDGPU=1
                  -DSANITIZER_HSA_INCLUDE_PATH="$AOMP_REPOS/$AOMP_ROCR_REPO_NAME/runtime/hsa-runtime/inc"
-                 -DSANITIZER_COMGR_INCLUDE_PATH="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/amd/comgr/include")
+                 -DSANITIZER_COMGR_INCLUDE_PATH="$AOMP_PROJECT_SRC/amd/comgr/include")
 fi
 
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
@@ -190,11 +190,11 @@ check_writable_installdir "$1" "$INSTALL_PROJECT"
 
 # Fix the banner to print the AOMP version string.
 if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
-   cd "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME" || exit
+   cd "$AOMP_PROJECT_SRC" || exit
    MONO_REPO_ID=$(git log | grep -m1 commit | cut -d" " -f2)
    SOURCEID="Source ID:$AOMP_VERSION_STRING-$MONO_REPO_ID"
    TEMPCLFILE="/tmp/clfile$$.cpp"
-   ORIGCLFILE="$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm/lib/Support/CommandLine.cpp"
+   ORIGCLFILE="$AOMP_PROJECT_SRC/llvm/lib/Support/CommandLine.cpp"
    BUILDCLFILE=$ORIGCLFILE
 
    if ! sed "s/LLVM (http:\/\/llvm\.org\/):/AOMP-${AOMP_VERSION_STRING} ($WEBSITE):\\\n $SOURCEID/" "$ORIGCLFILE" > "$TEMPCLFILE"; then
@@ -244,11 +244,11 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    MYLITOPTS=(-DLLVM_LIT_ARGS='-vv --show-unsupported --show-xfail -j 16')
    echo "${AOMP_CMAKE}" "$(shquot "${MYLITOPTS[@]}")" \
                         "$(shquot "${MYCMAKEOPTS[@]}")" \
-                        "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm"
+                        "$AOMP_PROJECT_SRC/llvm"
 
    if ! ${AOMP_CMAKE} "${MYLITOPTS[@]}" \
                       "${MYCMAKEOPTS[@]}" \
-                      "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm" 2>&1; then
+                      "$AOMP_PROJECT_SRC/llvm" 2>&1; then
       echo "ERROR cmake failed. Cmake flags"
       echo "      $(shquot "${MYCMAKEOPTS[@]}")"
       exit 1
@@ -306,7 +306,7 @@ if [ "$1" == "install" ] ; then
    $SUDO cp -p "$BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME/bin/count" "$LLVM_INSTALL_LOC/bin/count"
    $SUDO cp -p "$BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME/bin/not" "$LLVM_INSTALL_LOC/bin/not"
    $SUDO cp -p "$BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME/bin/yaml-bench" "$LLVM_INSTALL_LOC/bin/yaml-bench"
-   cd "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME" || exit
+   cd "$AOMP_PROJECT_SRC" || exit
    git checkout llvm/lib/Support/CommandLine.cpp
    echo
    echo "SUCCESSFUL INSTALL to $INSTALL_PROJECT with link to $AOMP"


### PR DESCRIPTION
Add AOMP_PROJECT_SRC, AOMP_SPIRV_SRC, and AOMP_SRC to aomp_common_vars and use them throughout the build_* scripts instead of hardcoding $AOMP_REPOS/<name>. Defaults preserve the historical $AOMP_REPOS layout, so behavior is unchanged when the variables are unset.

This lets a single environment override redirect one component's source (e.g. to a per-task git worktree) without relocating the shared checkout of every other component. The llvm-project monorepo root is read by eight build scripts (project, offload, openmp, llvm_runtimes_standalone, comgr, libdevice, hipcc, extras) and must move together for a staged build to stay consistent; the previously hardcoded SPIRV-LLVM-Translator source is now overridable too.