### PR TITLE
[smoke-dev] Cover the no-variants of the oversubscription options

### DIFF
--- a/test/smoke-dev/c-heatx/Makefile
+++ b/test/smoke-dev/c-heatx/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = c-heatx.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CLANG        = clang -fopenmp-target-ignore-env-vars
+CLANG        = clang -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-dev/loop-dir-3/Makefile
+++ b/test/smoke-dev/loop-dir-3/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 # RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/loop-dir-4/Makefile
+++ b/test/smoke-dev/loop-dir-4/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = loop_dir_4.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/no-loop-4/Makefile
+++ b/test/smoke-dev/no-loop-4/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-fast -fno-openmp-target-ignore-env-vars
+CFLAGS       += -fopenmp-assume-no-thread-state -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/no-loop-4/Makefile
+++ b/test/smoke-dev/no-loop-4/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-assume-no-thread-state -fopenmp-assume-no-nested-parallelism
+CFLAGS       += -fopenmp-target-fast -fno-openmp-assume-teams-oversubscription -fno-openmp-assume-threads-oversubscription
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/no-loop-7/Makefile
+++ b/test/smoke-dev/no-loop-7/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -O3 -fno-openmp-target-ignore-env-vars -fopenmp-target-fast
+CFLAGS       += -O3  -fopenmp-assume-no-thread-state -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/no-loop-7/Makefile
+++ b/test/smoke-dev/no-loop-7/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -O3  -fopenmp-assume-no-thread-state -fopenmp-assume-no-nested-parallelism
+CFLAGS       += -O3 -fopenmp-target-fast -fno-openmp-assume-teams-oversubscription -fno-openmp-assume-threads-oversubscription
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/opt-kernel-global-iv/Makefile
+++ b/test/smoke-dev/opt-kernel-global-iv/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/xteam-red-1/Makefile
+++ b/test/smoke-dev/xteam-red-1/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/xteam-red-4/Makefile
+++ b/test/smoke-dev/xteam-red-4/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-dev/xteam-red-fast-1/Makefile
+++ b/test/smoke-dev/xteam-red-fast-1/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-target-fast-reduction
+CFLAGS       += -fopenmp-target-fast-reduction
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-limbo/no-loop-1/Makefile
+++ b/test/smoke-limbo/no-loop-1/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-limbo/no-loop-threads/Makefile
+++ b/test/smoke-limbo/no-loop-threads/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-limbo/opt-kernel-inner-pragma-1/Makefile
+++ b/test/smoke-limbo/opt-kernel-inner-pragma-1/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/collapse_parallel_spmd/Makefile
+++ b/test/smoke/collapse_parallel_spmd/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = collapse_parallel_spmd.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -O3 -fno-openmp-target-ignore-env-vars
+CFLAGS       += -O3
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/envvar-sync-async-perf/Makefile
+++ b/test/smoke/envvar-sync-async-perf/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = target-map.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -O3 -fno-openmp-target-ignore-env-vars
+CFLAGS       += -O3 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/envvar-sync-async/Makefile
+++ b/test/smoke/envvar-sync-async/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = envvar-sync-async.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -O3 -fno-openmp-target-ignore-env-vars
+CFLAGS       += -O3
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-1/Makefile
+++ b/test/smoke/loop-dir-1/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-2/Makefile
+++ b/test/smoke/loop-dir-2/Makefile
@@ -8,7 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 #RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-5/Makefile
+++ b/test/smoke/loop-dir-5/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = loop_dir_5.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-6/Makefile
+++ b/test/smoke/loop-dir-6/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 # RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-7/Makefile
+++ b/test/smoke/loop-dir-7/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = loop_dir_7.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-8/Makefile
+++ b/test/smoke/loop-dir-8/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/loop-dir-9/Makefile
+++ b/test/smoke/loop-dir-9/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/matmul_parallel_spmd/Makefile
+++ b/test/smoke/matmul_parallel_spmd/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = matmul_parallel_spmd.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS       += -O3 -fno-openmp-target-ignore-env-vars
+CFLAGS       += -O3
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/no-loop-8/Makefile
+++ b/test/smoke/no-loop-8/Makefile
@@ -8,7 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/no-loop-sched/Makefile
+++ b/test/smoke/no-loop-sched/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/no-loop-split-with-inner-private-clause/Makefile
+++ b/test/smoke/no-loop-split-with-inner-private-clause/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/no-loop-with-continue/Makefile
+++ b/test/smoke/no-loop-with-continue/Makefile
@@ -8,7 +8,7 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
-CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+CFLAGS       += -fopenmp-assume-teams-oversubscription -fopenmp-assume-threads-oversubscription -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)


### PR DESCRIPTION
no-loop-4 and no-loop-7 were the only tests that combined
-fopenmp-target-fast with the negative ignore-env-vars flag, so they are the
ones that get the replacement negative variants. The remaining tests only
dropped the flag, it did nothing there without target-fast.

Depends on: ROCm/aomp#2053
Depends on: ROCm/llvm-project#1698
